### PR TITLE
Finished logic for not allowing to choose opponent piece

### DIFF
--- a/LaboonChess/src/main/java/LaboonChessDocumentController.java
+++ b/LaboonChess/src/main/java/LaboonChessDocumentController.java
@@ -213,6 +213,11 @@ public class LaboonChessDocumentController implements Initializable {
                 /* DO NOTHING: no chess piece here */
                 isFirstClick = true;                                        // reset
 
+            } else if ((chessboard.turn() == 'w' && ((ImageView)curSquare.getChildren().get(0)).getId().matches("[a-z]"))
+                    || (chessboard.turn() == 'b' && ((ImageView)curSquare.getChildren().get(0)).getId().matches("[A-Z]"))) {
+                /* DO NOTHING: user clicked on the opposing team's chess piece */
+                isFirstClick = true;
+
             } else {
                 /* FIRST-CLICK: set up for the second click */
                 guiChessSquare = curSquare;                                 // hold reference to this square
@@ -245,12 +250,19 @@ public class LaboonChessDocumentController implements Initializable {
                     curSquare.getChildren().remove(0);                      // remove the current chess piece
                     curSquare.getChildren().add(0, guiChessPiece);          // insert the first-click piece onto this square
                 }
-            }
-            // finished with second-click
-            isFirstClick = true;                        // back to start (wait for a "first-click" again)
-            guiChessPiece.setOpacity(1);                // opacity set back to show finished
 
-            System.out.println(chessboard.toFEN());     // DEBUG
+                // finished with second-click
+                isFirstClick = true;                        // back to start (wait for a "first-click" again)
+                guiChessPiece.setOpacity(1);                // opacity set back to show finished
+
+                System.out.println(chessboard.toFEN());     // DEBUG
+
+            } else if (guiChessSquare.equals(curSquare)) {
+                /* USER CLICKED ON CURRENTLY HIGHLIGHTED PIECE */
+
+                isFirstClick = true;                        // back to start
+                guiChessPiece.setOpacity(1);                // Unhighlight the currently highlighted piece
+            }
         }
     }
 }

--- a/LaboonChess/src/main/java/entities/ChessBoard.java
+++ b/LaboonChess/src/main/java/entities/ChessBoard.java
@@ -258,7 +258,7 @@ public class ChessBoard {
      Returns whose turn it is
      @Return: char 'w' if whites turn, 'b' if blacks turn
      */
-    private char turn(){
+    public char turn(){
         if (turn == 0) {
             return 'w';
         } else {


### PR DESCRIPTION
- ChessBoard.turn() method turned public to determine who's turn it
  was. This was needed in the LaboonChessDocumentController logic.
- The logic now includes a handler for the user for three cases; they
  all depend on the fact the user has already clicked on their chess
  piece and it has been highlighted:
  
  1) If they click on the opponent's piece, nothing happens. The
      logic still assumes it is the second-click and waits for a
      legal move to be done.
  
  2) If they click on a space that is an illegal move, their first-
      click piece stays highlighted and the logic follows to wait for
      a legal move to be done (it's still their "second-click" action).
  
  3) If they click on the chess piece that they first clicked on, then
      an "un-highlight" action occurs; the chess piece is no longer
      highlighted and the logic now follows that it is the user's
      first-click and no longer their second-click action.
