### PR TITLE
Refactored ChessBoard.isLegal() method to enable Pawn Promotion

### DIFF
--- a/LaboonChess/src/main/java/entities/ChessBoard.java
+++ b/LaboonChess/src/main/java/entities/ChessBoard.java
@@ -55,15 +55,13 @@ public class ChessBoard {
             moves = MoveGenerator.getInstance().generateLegalMoves(board);
             String actualMove = sanFrom + sanTo;
 
-            for (Move move : moves) {
-                System.out.println(move.toString() + " " + actualMove);
-                if (move.toString().equals(actualMove)) {
-                    return true;
-                }
+            // performs lazy matching to see if the actualMove
+            //      is contained within the list of legal moves
+            if (moves.toString().contains(actualMove)) {
+                return true;
+            } else {
+                return false;
             }
-
-            return false;
-
         } catch (MoveGeneratorException e) {
             e.printStackTrace();
         }


### PR DESCRIPTION
Pawn promotion is being allowed now, and the logic for this method
has been changed to perform a more lazy match to see if the move
the user wants to perform is contained within the list of legal moves.
